### PR TITLE
Implement profiles for the Genesis controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,37 @@ SNES:
 * 8BitDo SN30 2.4G Receiver
 * 8BitDo SNES Retro Receiver
 
+## MiSTer mode on 8bitdo M30 controller
+
+The Triple Controller exposes three "players" on one USB device.  Unfortunately
+MiSTer does not support setting keymaps per "player", MiSTer mode works around
+this by making sure the positional mapping is the same between all controllers.
+
+MiSTer mode can be toggled on and off with "HOME + Z" (you have to press HOME
+first, Z second). This setting is saved to EEPROM and preserved across power
+cycles. The default is "normal mode".
+
+When the Genesis controller is in MiSTer mode:
+
+- The HOME button sends "DOWN + MODE" (This is because no equivalent of the
+  HOME button exists on the other controller ports)
+
+- Buttons are swapped: A with B and X with Y. This is such that the position of
+  the buttons is consistent between SNES and Genesis.
+
 ## V2 Controller Button Mapping
 ```
-Button   NES        SNES       GENESIS
----------------------------------------------
-01       B          B          B
-02       A          A          A
-03       N/A        Y          Y
-04       N/A        X          X
-05       N/A        L          Z
-06       N/A        R          C
-07       SELECT     SELECT     MODE
-08       START      START      START
-09       N/A        N/A        HOME (8BitDo)
+Button   NES        SNES       GENESIS (normal)    GENESIS (MiSTer)
+-------------------------------------------------------------------
+01       B          B          B                   A 
+02       A          A          A                   B
+03       N/A        Y          Y                   X
+04       N/A        X          X                   Y
+05       N/A        L          Z                   Z
+06       N/A        R          C                   C
+07       SELECT     SELECT     MODE                MODE
+08       START      START      START               START
+09       N/A        N/A        HOME (8BitDo)       (N/A but HOME will send MODE + DOWN)
 ```
 
 ## MiSTer Home Menu Suggestion

--- a/TripleUSBController-V2.1/Makefile
+++ b/TripleUSBController-V2.1/Makefile
@@ -1,0 +1,48 @@
+# To generate the fqbn (Fully Qualified Board Name) for the "BOARD" variable
+# below, if you are already using the IDE look at preferences.txt (Linked from
+# file/Preferences). Find:
+# - target_package (example: SparkFun)
+# - target_platform (should be: avr)
+# - board (example: promicro)
+# - cpu (should be 16MHzatmega32U4)
+#
+# For instance with a SparkFun Pro Micro the fqbn becomes the |BOARD| variable below.
+# To install the needed dependencies look at the install-sparkfun example below and
+# modify to your needs.
+
+BOARD = SparkFun:avr:promicro:cpu=16MHzatmega32U4
+
+SERIAL = /dev/ttyACM0
+
+SPARKFUN-URLS = https://raw.githubusercontent.com/sparkfun/Arduino_Boards/master/IDE_Board_Manager/package_sparkfun_index.json
+
+EXTRA_FLAGS =
+OUTPUT_DIR = build
+
+# This is believed to match how arduino-cli works, i.e. it uses the name of the
+# current directory to infer the name of the main .ino file.
+PROJECT_FILE = $(notdir $(CURDIR)).ino
+
+
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+  EXTRA_FLAGS += --build-property compiler.cpp.extra_flags=-DDEBUG
+  OUTPUT_DIR = debug-build
+endif
+
+all: compile
+
+clean:
+	rm -rf $(OUTPUT_DIR)
+
+compile: $(OUTPUT_DIR)/$(PROJECT_FILE).hex
+
+$(OUTPUT_DIR)/$(PROJECT_FILE).hex: $(wildcard *.cpp) $(wildcard *.h) $(PROJECT_FILE)
+	arduino-cli compile $(EXTRA_FLAGS) --output-dir "$(OUTPUT_DIR)" -b "$(BOARD)" -e
+
+upload: compile
+	arduino-cli upload -v --input-dir "$(OUTPUT_DIR)" -b  "$(BOARD)" -p $(SERIAL) -t
+
+install-sparkfun:
+	arduino-cli core update-index --additional-urls "$(SPARKFUN-URLS)"
+	arduino-cli core install arduino:avr Sparkfun:avr --additional-urls "$(SPARKFUN-URLS)"

--- a/TripleUSBController-V2.1/SegaController32U4.h
+++ b/TripleUSBController-V2.1/SegaController32U4.h
@@ -73,11 +73,23 @@ const byte SC_CYCLE_DELAY = 10; // Delay (µs) between setting the select pin an
 class SegaController32U4 
 {
   public:
-    SegaController32U4(void);
-    word getStateMD();
+    // |eeprom_index| is the eeprom storage reserved for this instance.
+    SegaController32U4(int eeprom_index);
+    word updateState(void);
+    word getFinalState(void);
 
   private:
+    // Should A and B and X and Y be swapped?
+    void toggleMisterMode(void);
+    bool isMisterMode(void);
+
+    const int _eeprom_index;
+
+    // This acts as a cache to not routinely read EEPROM.
+    bool _misterMode;
+
     word _currentState;
+    word _previousState;
 
     boolean _pinSelect;
 

--- a/TripleUSBController-V2.1/TripleUSBController-V2.1.ino
+++ b/TripleUSBController-V2.1/TripleUSBController-V2.1.ino
@@ -110,10 +110,13 @@ void sendState();
 +--------------------------------+
 */
 
+// Manage EEPROM by making sure everything has
+// its own index.
+enum EEPROMIndices { GENESIS_EEPROM };
 
 // Set up USB HID gamepads
 Gamepad_ Gamepad[3];
-SegaController32U4 controller;
+SegaController32U4 controller(GENESIS_EEPROM);
 
 // Controllers
 uint32_t  controllerData[2][2] = {{0,0},{0,0}};
@@ -215,11 +218,13 @@ void loop()
     //8 cycles needed to capture 6-button controllers
     for(uint8_t i = 0; i < 8; i++)
     {
-      currentState = controller.getStateMD();
-      Gamepad[GENESIS]._GamepadReport.buttons = currentState >> 4;
-      Gamepad[GENESIS]._GamepadReport.Y = ((currentState & SC_BTN_DOWN) >> SC_BIT_SH_DOWN) - ((currentState & SC_BTN_UP) >> SC_BIT_SH_UP);
-      Gamepad[GENESIS]._GamepadReport.X = ((currentState & SC_BTN_RIGHT) >> SC_BIT_SH_RIGHT) - ((currentState & SC_BTN_LEFT) >> SC_BIT_SH_LEFT);
+      currentState = controller.updateState();
     }
+
+    currentState = controller.getFinalState();
+    Gamepad[GENESIS]._GamepadReport.buttons = currentState >> 4;
+    Gamepad[GENESIS]._GamepadReport.Y = ((currentState & SC_BTN_DOWN) >> SC_BIT_SH_DOWN) - ((currentState & SC_BTN_UP) >> SC_BIT_SH_UP);
+    Gamepad[GENESIS]._GamepadReport.X = ((currentState & SC_BTN_RIGHT) >> SC_BIT_SH_RIGHT) - ((currentState & SC_BTN_LEFT) >> SC_BIT_SH_LEFT);
 
     for(uint8_t j = 0; j < 1; j++)
     {


### PR DESCRIPTION
Profiles are saved to EEPROM and preserved across power ups. This implements a "MiSTer" mode on top of the "normal" mode that matches the positional mappings of the buttons across all three ports (and sends DOWN + SELECT when the HOME button is pressed on a M30).